### PR TITLE
perf(valuecodec): reuse a shared zstd encoder/decoder instead of one per call

### DIFF
--- a/pkg/valuecodec/valuecodec.go
+++ b/pkg/valuecodec/valuecodec.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"math"
+	"sync"
 
 	"github.com/klauspost/compress/zstd"
 )
@@ -199,24 +200,48 @@ func (z *Zstd) Name() string {
 	return "zstd"
 }
 
+// The zstd encoder and decoder are process-lived singletons shared across all
+// Zstd values. Each carries multi-MB window/hash tables, so constructing one
+// per call dominates heap allocation; (*Encoder).EncodeAll and
+// (*Decoder).DecodeAll are safe for concurrent use, so a single shared instance
+// is the documented reuse pattern. They are lazily built once and must never be
+// Closed: Close tears down the internal worker pool and breaks reuse.
+var (
+	zstdEncoderOnce sync.Once
+	zstdEncoder     *zstd.Encoder
+	zstdEncoderErr  error
+
+	zstdDecoderOnce sync.Once
+	zstdDecoder     *zstd.Decoder
+	zstdDecoderErr  error
+)
+
+func sharedZstdEncoder() (*zstd.Encoder, error) {
+	zstdEncoderOnce.Do(func() {
+		zstdEncoder, zstdEncoderErr = zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+	})
+	return zstdEncoder, zstdEncoderErr
+}
+
+func sharedZstdDecoder() (*zstd.Decoder, error) {
+	zstdDecoderOnce.Do(func() {
+		zstdDecoder, zstdDecoderErr = zstd.NewReader(nil)
+	})
+	return zstdDecoder, zstdDecoderErr
+}
+
 func (z *Zstd) Compress(src []byte) ([]byte, error) {
-	encoder, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+	encoder, err := sharedZstdEncoder()
 	if err != nil {
 		return nil, err
 	}
-	encoded := encoder.EncodeAll(src, nil)
-	if closeErr := encoder.Close(); closeErr != nil {
-		return nil, fmt.Errorf("close encoder: %w", closeErr)
-	}
-	return encoded, nil
+	return encoder.EncodeAll(src, nil), nil
 }
 
 func (z *Zstd) Decompress(src []byte) ([]byte, error) {
-	decoder, err := zstd.NewReader(nil)
+	decoder, err := sharedZstdDecoder()
 	if err != nil {
 		return nil, err
 	}
-	defer decoder.Close()
-
 	return decoder.DecodeAll(src, nil)
 }

--- a/pkg/valuecodec/valuecodec_concurrency_test.go
+++ b/pkg/valuecodec/valuecodec_concurrency_test.go
@@ -1,0 +1,132 @@
+package valuecodec
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldRoundTripConcurrentlyWhenSharedZstdReused(t *testing.T) {
+	// Arrange
+	codec := New(testConfig())
+	zstdAlgo := NewZstd()
+
+	const goroutines = 64
+	const iterations = 200
+
+	// Act
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errCh := make(chan error, goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				value := []byte(fmt.Sprintf("goroutine-%d-iteration-%d-", id, i))
+				for len(value) < 512 {
+					value = append(value, value...)
+				}
+
+				encoded, err := codec.Encode(value)
+				if err != nil {
+					errCh <- fmt.Errorf("encode: %w", err)
+					return
+				}
+				decoded, err := codec.Decode(encoded)
+				if err != nil {
+					errCh <- fmt.Errorf("decode: %w", err)
+					return
+				}
+				if string(decoded) != string(value) {
+					errCh <- fmt.Errorf("round trip mismatch for goroutine %d iteration %d", id, i)
+					return
+				}
+
+				// Exercise the algorithm layer directly, bypassing the codec
+				// thresholds, so the shared encoder/decoder see raw concurrent use.
+				compressed, err := zstdAlgo.Compress(value)
+				if err != nil {
+					errCh <- fmt.Errorf("compress: %w", err)
+					return
+				}
+				restored, err := zstdAlgo.Decompress(compressed)
+				if err != nil {
+					errCh <- fmt.Errorf("decompress: %w", err)
+					return
+				}
+				if string(restored) != string(value) {
+					errCh <- fmt.Errorf("direct round trip mismatch for goroutine %d iteration %d", id, i)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errCh)
+
+	// Assert
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+}
+
+func benchmarkPayload() []byte {
+	payload := []byte("compressible-benchmark-payload-")
+	for len(payload) < 4096 {
+		payload = append(payload, payload...)
+	}
+	return payload
+}
+
+func BenchmarkZstdCompressShared(b *testing.B) {
+	z := NewZstd()
+	payload := benchmarkPayload()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := z.Compress(payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkZstdDecompressShared(b *testing.B) {
+	z := NewZstd()
+	payload := benchmarkPayload()
+	compressed, err := z.Compress(payload)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := z.Decompress(compressed); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkZstdCompressPerCall reproduces the OLD per-call construction path
+// locally (it does not touch production code) so the allocs/op reduction of the
+// shared encoder is demonstrable side by side.
+func BenchmarkZstdCompressPerCall(b *testing.B) {
+	payload := benchmarkPayload()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = encoder.EncodeAll(payload, nil)
+		if err := encoder.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`valuecodec.Zstd.Compress` and `Decompress` construct a brand-new `zstd.Encoder`/`zstd.Decoder` on **every call** (`zstd.NewWriter`/`zstd.NewReader`) and then `Close()` it. Each constructor allocates the multi-MB `SpeedFastest` window/hash tables, so on a write-heavy workload encoder construction dominates heap allocation.

Profiling a downstream service (Azure-Table + Pebble backed) attributed **~90% of all heap allocation** to `zstd.encoderOptions.encoder` (~70%) + `zstd.(*blockEnc).init` (~20%) — all under `valuecodec.(*Codec).Encode` — driving ~1 GB/s allocation and a `runtime.memclrNoHeapPointers` flat cost of ~12% of CPU.

## Fix

Construct the encoder and decoder **once** via `sync.Once` and reuse them. `(*Encoder).EncodeAll` and `(*Decoder).DecodeAll` are documented safe for concurrent use by multiple goroutines (each call leases its own scratch state from an internal buffered channel). The shared instances are intentionally **never `Close()`d** — `Close()` tears down the internal worker pool and would break reuse. Construction errors are still surfaced through the existing `(…, error)` returns.

## Evidence

Benchmarks (Apple M4 Pro, `SpeedFastest`), new path vs. a local reproduction of the old per-call path:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| Compress (old, per-call) | 90,944 | 4,120,069 | 48 |
| Compress (shared) | 2,502 | 8,192 | 1 |

~36× faster, ~503× less memory, 48→1 allocs/op. Decompress is likewise 1 alloc/op.

## Compatibility & tests

- On-wire envelope (magic/version/CRC/decoded-size), `SpeedFastest` level, the `Algorithm` interface, `AlgorithmID` values, and all exported signatures are **unchanged**; the existing `valuecodec_test.go` passes unmodified.
- Adds `TestShouldRoundTripConcurrentlyWhenSharedZstdReused` (64 goroutines × 200 iterations, passes under `go test -race`) and before/after `-benchmem` benchmarks.
